### PR TITLE
adding initial header content

### DIFF
--- a/ffd_info_exchange/fafsa/static/assets/css/main.css
+++ b/ffd_info_exchange/fafsa/static/assets/css/main.css
@@ -1,0 +1,15 @@
+/* USWDS Overrides */
+
+.usa-banner-inner {
+  padding: 0;
+}
+
+.usa-header-extended .usa-navbar {
+  padding: 0;
+}
+
+/* Other CSS */
+
+.main-content {
+  padding-top: 4rem; 
+}

--- a/ffd_info_exchange/fafsa/static/assets/css/main.css
+++ b/ffd_info_exchange/fafsa/static/assets/css/main.css
@@ -10,6 +10,10 @@
 
 /* Other CSS */
 
+.disclaimer-right {
+  float: right;
+}
+
 .main-content {
-  padding-top: 4rem; 
+  padding-top: 4rem;
 }

--- a/ffd_info_exchange/fafsa/templates/base.html
+++ b/ffd_info_exchange/fafsa/templates/base.html
@@ -6,6 +6,7 @@
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <title>{% block title %}FAFSA - Federal Student Aid{% endblock %}</title>
       <link rel="stylesheet" href="{% static "css/uswds.min.css" %}">
+      <link rel="stylesheet" href="{% static "assets/css/main.css" %}">
       <style type="text/css">
         .help-text {
             font-style: italic;
@@ -14,11 +15,14 @@
       </style>
   </head>
   <body>
-    <div class="usa-grid-full">
-      <div class="usa-width-one-whole">
-        {% block content %}{% endblock %}
+    {% include 'includes/header.html' %}
+    <main class="main-content">
+      <div class="usa-grid-full">
+        <div class="usa-width-one-whole">
+          {% block content %}{% endblock %}
+        </div>
       </div>
-    </div>
+    </main> 
   <script src="{% static "js/uswds.min.js" %}"></script>
   </body>
 </html>

--- a/ffd_info_exchange/fafsa/templates/fafsa_form.html
+++ b/ffd_info_exchange/fafsa/templates/fafsa_form.html
@@ -3,27 +3,6 @@
 
 {% block content %}
   {% load floppyforms %}
-    <header class="usa-site-header disclaimer" role="banner">
-
-      <div class="usa-disclaimer">
-        <div class="usa-grid-no-padding">
-          <div class="usa-width-one-whole">
-            <div class="disclaimer-left">
-                <span class="usa-disclaimer-official">
-                  An official website of the United States Government
-                  <img class="usa-flag_icon" alt="U.S. flag signifying that this is a United States Federal Government website" src="{% static 'assets/img/usa-flag.png' %}">
-                </span>
-              </div>
-              <div class="disclaimer-right">
-                <span>
-                  This site is a <a href="https://18f.gsa.gov/dashboard/stages/#discovery">discovery prototype</a>.
-                </span>
-              </div>
-          </div>
-        </div>
-      </div>
-
-    </header>
   <h1>Welcome to the FAFSA!</h1>
   <p>To complete this form and be considered for federal financial aid, you’ll need to answer a series of questions about yourself, your parents, and your financial history.</p>
 

--- a/ffd_info_exchange/fafsa/templates/includes/header.html
+++ b/ffd_info_exchange/fafsa/templates/includes/header.html
@@ -1,0 +1,63 @@
+<a class="usa-skipnav" href="#main-content">Skip to main content</a>
+<header class="usa-header usa-header-extended header-custom" role="banner">
+  <!-- Gov banner BEGIN -->
+  <div class="usa-banner">
+    <div class="usa-accordion">
+      <header class="usa-banner-header">
+        <div class="usa-grid usa-banner-inner">
+        <img src="/static/img/favicons/favicon-57.png" alt="U.S. flag">
+        <p>An official website of the United States government</p>
+        <button class="usa-accordion-button usa-banner-button"
+          aria-expanded="false" aria-controls="gov-banner">
+          <span class="usa-banner-button-text">Here's how you know</span>
+        </button>
+        </div>
+      </header>
+      <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
+        <div class="usa-banner-guidance-gov usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="/static/img/icon-dot-gov.svg" alt="Dot gov">
+          <div class="usa-media_block-body">
+            <p>
+              <strong>The .gov means it’s official.</strong>
+              <br>
+              Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+            </p>
+          </div>
+        </div>
+        <div class="usa-banner-guidance-ssl usa-width-one-half">
+          <img class="usa-banner-icon usa-media_block-img" src="/static/img/icon-https.svg" alt="SSL">
+          <div class="usa-media_block-body">
+            <p>This site is also protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- Gov banner END -->
+  <div class="usa-navbar">
+    <button class="usa-menu-btn">Menu</button>
+    <div class="usa-logo" id="logo">
+      <em class="usa-logo-text">
+        <a href="#" accesskey="1" title="Home" aria-label="Home">FAFSA Student Application</a>
+      </em>
+    </div>
+  </div>
+  <nav role="navigation" class="usa-nav">
+    <div class="usa-nav-inner">
+      <button class="usa-nav-close">
+        <img src="/assets/img/close.svg" alt="close">
+      </button>
+      <div class="usa-nav-secondary">
+        <ul class="usa-unstyled-list usa-nav-secondary-links">
+          <li>
+            <a href="#">Help</a>
+          </li>
+          <li>
+            <a href="#">Log Out</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+</header>
+<div class="usa-overlay"></div>

--- a/ffd_info_exchange/fafsa/templates/includes/header.html
+++ b/ffd_info_exchange/fafsa/templates/includes/header.html
@@ -45,15 +45,12 @@
   <nav role="navigation" class="usa-nav">
     <div class="usa-nav-inner">
       <button class="usa-nav-close">
-        <img src="/assets/img/close.svg" alt="close">
+        <img src="/static/img/close.svg" alt="close">
       </button>
       <div class="usa-nav-secondary">
         <ul class="usa-unstyled-list usa-nav-secondary-links">
           <li>
             <a href="#">Help</a>
-          </li>
-          <li>
-            <a href="#">Log Out</a>
           </li>
         </ul>
       </div>

--- a/ffd_info_exchange/fafsa/templates/includes/header.html
+++ b/ffd_info_exchange/fafsa/templates/includes/header.html
@@ -5,12 +5,13 @@
     <div class="usa-accordion">
       <header class="usa-banner-header">
         <div class="usa-grid usa-banner-inner">
-        <img src="/static/img/favicons/favicon-57.png" alt="U.S. flag">
-        <p>An official website of the United States government</p>
-        <button class="usa-accordion-button usa-banner-button"
-          aria-expanded="false" aria-controls="gov-banner">
-          <span class="usa-banner-button-text">Here's how you know</span>
-        </button>
+          <img src="/static/img/favicons/favicon-57.png" alt="U.S. flag">
+          <p>An official website of the United States government</p>
+          <button class="usa-accordion-button usa-banner-button"
+            aria-expanded="false" aria-controls="gov-banner">
+            <span class="usa-banner-button-text">Here's how you know</span>
+          </button>
+          <p class="disclaimer-right">This site is a <a href="https://18f.gsa.gov/dashboard/stages/#discovery">discovery prototype</a>.</p>
         </div>
       </header>
       <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
@@ -38,7 +39,7 @@
     <button class="usa-menu-btn">Menu</button>
     <div class="usa-logo" id="logo">
       <em class="usa-logo-text">
-        <a href="#" accesskey="1" title="Home" aria-label="Home">FAFSA Student Application</a>
+        <a href="#" accesskey="1" title="Home" aria-label="Home">Federal Student Aid</a>
       </em>
     </div>
   </div>


### PR DESCRIPTION
![screen shot 2016-10-28 at 11 18 04 am](https://cloud.githubusercontent.com/assets/776987/19813671/60df32e4-9d00-11e6-9c9d-d1b3a92d0f08.png)

This code is to add the header and breaks the header out into a separate include template. Stylesheets are linked up in what is probably a temporary solution that will change if we introduce Sass and get more than a handful of lines of code. 
