### PR TITLE
Upgrade Django to 1.10.3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django>=1.10.2
+Django>=1.10.3
 psycopg2
 selenium
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file ../requirements.txt ../requirements.in
 #
 django-floppyforms==1.7.0
-Django==1.10.2
+Django==1.10.3
 psycopg2==2.6.2
 selenium==3.0.1
 whitenoise==3.2.2


### PR DESCRIPTION
Minor security release. See https://docs.djangoproject.com/en/1.10/releases/1.10.3/ for further information.