### PR TITLE
re-aligning form progress buttons

### DIFF
--- a/ffd_info_exchange/fafsa/static/assets/css/main.css
+++ b/ffd_info_exchange/fafsa/static/assets/css/main.css
@@ -1,5 +1,10 @@
 /* USWDS Overrides */
 
+form [type="submit"], form [type="submit"] {
+  display: inline-block;
+  height: 4.4rem;
+}
+
 .usa-banner-inner {
   padding: 0;
 }

--- a/ffd_info_exchange/fafsa/templates/base.html
+++ b/ffd_info_exchange/fafsa/templates/base.html
@@ -22,7 +22,7 @@
           {% block content %}{% endblock %}
         </div>
       </div>
-    </main> 
+    </main>
   <script src="{% static "js/uswds.min.js" %}"></script>
   </body>
 </html>

--- a/ffd_info_exchange/fafsa/templates/fafsa_form.html
+++ b/ffd_info_exchange/fafsa/templates/fafsa_form.html
@@ -1,5 +1,4 @@
 {% extends 'base.html' %}
-{% load static from staticfiles %}
 {% load i18n %}
 
 {% block head %}
@@ -27,15 +26,11 @@
         {{ wizard.form }}
     {% endif %}
 
-  {% if wizard.steps.prev %}
-    <div class="button_wrapper">
-      <button class="usa-button-small" name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}">{% trans "first step" %}</button>
-      <button class="usa-button-small" name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% trans "prev step" %}</button>
-    </div>
-  {% endif %}
-
   <div class="button_wrapper">
-    <input type="submit" value="{% trans "submit" %}"/>
+    {% if wizard.steps.prev %}
+      <button class="usa-button-small" name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">{% trans "Previous Step" %}</button>
+    {% endif %}
+    <input type="submit" value="{% trans "Next" %}"/>
   </div>
 </form>
 


### PR DESCRIPTION
- adding some css overrides for USWDS code to put the forward/back buttons on the same line
- removing "first step" button
- removing unnecessary static file loading line (they are already loaded in the template this one extends) 

![screen shot 2016-11-10 at 12 42 01 pm](https://cloud.githubusercontent.com/assets/776987/20189585/77c258f4-a743-11e6-9c06-ffd18fc0def4.png)

