### PR TITLE
Add help text for bonus service options

### DIFF
--- a/ffd_info_exchange/ffd_info_exchange/static/assets/css/main.css
+++ b/ffd_info_exchange/ffd_info_exchange/static/assets/css/main.css
@@ -119,6 +119,15 @@ label {
   display: none;
 }
 
+.optional-services-block > .body-text {
+  display: inline-block;
+  width: auto;
+}
+
+.optional-services-block > .tooltip {
+  margin-top: 1.7rem;
+}
+
 /* for the unique way form fields are presented below a list paragraph */
 .signature-form label:first-of-type {
   margin-top: 1.5rem;

--- a/ffd_info_exchange/uscis/templates/select-bonus-services.html
+++ b/ffd_info_exchange/uscis/templates/select-bonus-services.html
@@ -10,6 +10,10 @@
 
   <div class="optional-services-block">
     <p class="body-text">
+      <div class="tooltip">
+        <p class="tooltip-text" id="tooltip-text-labels">Changing your name now will save time and additional expenses later on. Name-change policies vary by state; check your state’s policies for more guidance.</p>
+        <a class="usa-label label-beta" href="#" aria-describedby="tooltip-text-labels">?</a>
+      </div>
       Would you like to apply to legally <strong>change your name</strong>?<br />
       <em>You've currently answered 95% of the necessary questions.</em>
       {% if bonuses_completed.name_change %}
@@ -23,6 +27,10 @@
       {% endif %}
     </p>
     <p class="body-text">
+      <div class="tooltip">
+        <p class="tooltip-text" id="tooltip-text-labels">These services let travelers enjoy expedited security screening at participating airports.</p>
+        <a class="usa-label label-beta" href="#" aria-describedby="tooltip-text-labels">?</a>
+      </div>
       Would you like to <strong>apply for Global Entry/TSA PreCheck</strong>?<br />
       <em>You've currently answered 70% of the necessary questions.</em>
       {% if bonuses_completed.global_entry %}
@@ -36,6 +44,10 @@
       {% endif %}
     </p>
     <p class="body-text">
+      <div class="tooltip">
+        <p class="tooltip-text" id="tooltip-text-labels">A U.S. passport is a form of identification that serves as proof of U.S. citizenship. It’s required for travel to other countries and to return to the United States after travel abroad.</p>
+        <a class="usa-label label-beta" href="#" aria-describedby="tooltip-text-labels">?</a>
+      </div>
       Would you like to <strong>apply for a U.S. passport</strong>?<br />
       <em>You've currently answered 85% of the necessary questions.</em>
       {% if bonuses_completed.passport %}

--- a/ffd_info_exchange/uscis/templates/select-bonus-services.html
+++ b/ffd_info_exchange/uscis/templates/select-bonus-services.html
@@ -10,11 +10,12 @@
 
   <div class="optional-services-block">
     <p class="body-text">
+      Would you like to apply to legally <strong>change your name</strong>?
       <div class="tooltip">
         <p class="tooltip-text" id="tooltip-text-labels">Changing your name now will save time and additional expenses later on. Name-change policies vary by state; check your state’s policies for more guidance.</p>
         <a class="usa-label label-beta" href="#" aria-describedby="tooltip-text-labels">?</a>
       </div>
-      Would you like to apply to legally <strong>change your name</strong>?<br />
+      <br />
       <em>You've currently answered 95% of the necessary questions.</em>
       {% if bonuses_completed.name_change %}
         <div class="button-wrapper">
@@ -26,12 +27,14 @@
         </div>
       {% endif %}
     </p>
+
     <p class="body-text">
+      Would you like to <strong>apply for Global Entry/TSA PreCheck</strong>?
       <div class="tooltip">
         <p class="tooltip-text" id="tooltip-text-labels">These services let travelers enjoy expedited security screening at participating airports.</p>
         <a class="usa-label label-beta" href="#" aria-describedby="tooltip-text-labels">?</a>
       </div>
-      Would you like to <strong>apply for Global Entry/TSA PreCheck</strong>?<br />
+      <br />
       <em>You've currently answered 70% of the necessary questions.</em>
       {% if bonuses_completed.global_entry %}
         <div class="button-wrapper">
@@ -43,12 +46,14 @@
         </div>
       {% endif %}
     </p>
+
     <p class="body-text">
+      Would you like to <strong>apply for a U.S. passport</strong>?
       <div class="tooltip">
         <p class="tooltip-text" id="tooltip-text-labels">A U.S. passport is a form of identification that serves as proof of U.S. citizenship. It’s required for travel to other countries and to return to the United States after travel abroad.</p>
         <a class="usa-label label-beta" href="#" aria-describedby="tooltip-text-labels">?</a>
       </div>
-      Would you like to <strong>apply for a U.S. passport</strong>?<br />
+      <br />
       <em>You've currently answered 85% of the necessary questions.</em>
       {% if bonuses_completed.passport %}
         <div class="button-wrapper">


### PR DESCRIPTION
People may not know what Global Entry is, why they might want to apply to change their name now instead of later, etc. This PR adds tooltips with text meant to communicate the value of those options.

Positioning of these tooltips could be improved.

Closes https://github.com/18F/ffd-info-exchange/issues/156.